### PR TITLE
feat(frontend): keep channel in route

### DIFF
--- a/frontend/src/components/HeaderMenu.vue
+++ b/frontend/src/components/HeaderMenu.vue
@@ -59,7 +59,7 @@
                     </li>
                     <li class="bg-base-100 rounded-md">
                         <RouterLink
-                            to="/configure"
+                            :to="{ path: '/configure', query: { channel: configStore.channels[configStore.i]?.id } }"
                             class="h-[27px] leading-5"
                             active-class="is-active"
                             :title="t('button.configure')"
@@ -122,7 +122,7 @@
                 </li>
                 <li class="bg-base-100 rounded-md p-0">
                     <RouterLink
-                        to="/configure"
+                        :to="{ path: '/configure', query: { channel: configStore.channels[configStore.i]?.id } }"
                         class="h-[27px] leading-5"
                         active-class="is-active"
                         :title="t('button.configure')"
@@ -155,7 +155,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
@@ -175,12 +175,28 @@ const indexStore = useIndex()
 const menuDropdown = ref()
 const isOpen = ref(false)
 
-const menuItems = ref([
-    { label: 'home', name: t('button.home'), link: '/' },
-    { label: 'player', name: t('button.player'), link: '/player' },
-    { label: 'media', name: t('button.media'), link: '/media' },
-    { label: 'message', name: t('button.message'), link: '/message' },
-    { label: 'logging', name: t('button.logging'), link: '/logging' },
+const menuItems = computed(() => [
+    { label: 'home', name: t('button.home'), link: { path: '/' } },
+    {
+        label: 'player',
+        name: t('button.player'),
+        link: { path: '/player', query: { channel: configStore.channels[configStore.i]?.id } },
+    },
+    {
+        label: 'media',
+        name: t('button.media'),
+        link: { path: '/media', query: { channel: configStore.channels[configStore.i]?.id } },
+    },
+    {
+        label: 'message',
+        name: t('button.message'),
+        link: { path: '/message', query: { channel: configStore.channels[configStore.i]?.id } },
+    },
+    {
+        label: 'logging',
+        name: t('button.logging'),
+        link: { path: '/logging', query: { channel: configStore.channels[configStore.i]?.id } },
+    },
 ])
 
 function closeMenu() {
@@ -228,6 +244,10 @@ function selectChannel(index: number) {
 
     configStore.getPlayoutConfig()
     configStore.getPlayoutOutputs()
+
+    router.replace({
+        query: { ...router.currentRoute.value.query, channel: configStore.channels[index].id },
+    })
 }
 
 function toggleTheme() {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -51,6 +51,23 @@ router.beforeEach(async (to, from, next) => {
         // const loc = i18n.locale.value === 'en-US' ? '' : `${i18n.locale.value}/`
         next('/')
     } else {
+        if (auth.isLogin && String(to.name) !== 'home') {
+            const chan = Number(to.query.channel)
+            if (chan) {
+                const idx = configStore.channels.findIndex((c) => c.id === chan)
+                if (idx !== -1) {
+                    configStore.i = idx
+                }
+            } else if (configStore.channels.length > 0) {
+                next({
+                    name: to.name!,
+                    query: { ...to.query, channel: configStore.channels[configStore.i].id },
+                    replace: true,
+                })
+                return
+            }
+        }
+
         next()
     }
 })

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -4,20 +4,29 @@
             <SystemStats v-if="configStore.channels.length > 0" />
 
             <div class="w-full flex flex-wrap justify-center gap-1 md:gap-0 md:join mt-5">
-                <RouterLink to="/player" class="btn btn-primary join-item px-2">
+                <RouterLink
+                    :to="{ path: '/player', query: { channel: configStore.channels[configStore.i]?.id } }"
+                    class="btn btn-primary join-item px-2"
+                >
                     {{ t('button.player') }}
                 </RouterLink>
-                <RouterLink to="/media" class="btn btn-primary join-item px-2">
+                <RouterLink
+                    :to="{ path: '/media', query: { channel: configStore.channels[configStore.i]?.id } }"
+                    class="btn btn-primary join-item px-2"
+                >
                     {{ t('button.media') }}
                 </RouterLink>
                 <RouterLink
                     v-if="configStore.playout?.text?.add_text && !configStore.playout?.text?.text_from_filename"
-                    to="/message"
+                    :to="{ path: '/message', query: { channel: configStore.channels[configStore.i]?.id } }"
                     class="btn btn-primary join-item px-2"
                 >
                     {{ t('button.message') }}
                 </RouterLink>
-                <RouterLink to="/logging" class="btn btn-primary join-item px-2">
+                <RouterLink
+                    :to="{ path: '/logging', query: { channel: configStore.channels[configStore.i]?.id } }"
+                    class="btn btn-primary join-item px-2"
+                >
                     {{ t('button.logging') }}
                 </RouterLink>
                 <div class="dropdown">
@@ -32,7 +41,11 @@
                         </li>
                     </ul>
                 </div>
-                <RouterLink to="/configure" class="btn btn-primary join-item px-2" :title="t('button.configure')">
+                <RouterLink
+                    :to="{ path: '/configure', query: { channel: configStore.channels[configStore.i]?.id } }"
+                    class="btn btn-primary join-item px-2"
+                    :title="t('button.configure')"
+                >
                     <i class="bi bi-gear text-[17px]" />
                 </RouterLink>
                 <label class="join-item btn btn-primary swap swap-rotate px-2">


### PR DESCRIPTION
## Summary
- ensure router carries selected channel in query
- update navigation links and channel selector to sync with query

## Testing
- `npx eslint -c eslint.config.ts src` *(fails: 50 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a884669ebc8324930e0545b07f222b