### PR TITLE
Fix video preview MIME type handling for MKV files

### DIFF
--- a/frontend/src/composables/helper.ts
+++ b/frontend/src/composables/helper.ts
@@ -7,6 +7,42 @@ dayjs.extend(timezone)
 import { useConfig } from '@/stores/config'
 
 export const stringFormatter = () => {
+    const liveMimeType: Record<string, string> = {
+        m3u8: 'application/x-mpegURL',
+    }
+
+    const videoMimeTypeMap: Record<string, string> = {
+        avi: 'video/x-msvideo',
+        flv: 'video/x-flv',
+        m2v: 'video/mpeg',
+        m4v: 'video/x-m4v',
+        mkv: 'video/x-matroska',
+        mov: 'video/quicktime',
+        mp4: 'video/mp4',
+        mpeg: 'video/mpeg',
+        mpg: 'video/mpeg',
+        mts: 'video/mp2t',
+        mxf: 'application/mxf',
+        ts: 'video/mp2t',
+        vob: 'video/x-ms-vob',
+        ogv: 'video/ogg',
+        webm: 'video/webm',
+        wmv: 'video/x-ms-wmv',
+    }
+
+    const audioMimeTypeMap: Record<string, string> = {
+        aac: 'audio/aac',
+        aiff: 'audio/aiff',
+        flac: 'audio/flac',
+        m4a: 'audio/mp4',
+        mp2: 'audio/mpeg',
+        mp3: 'audio/mpeg',
+        ogg: 'audio/ogg',
+        opus: 'audio/opus',
+        wav: 'audio/wav',
+        wma: 'audio/x-ms-wma',
+    }
+
     function fileSize(bytes: number | undefined, dp = 2) {
         if (!bytes) {
             return 0.0
@@ -106,26 +142,6 @@ export const stringFormatter = () => {
     }
 
     function mediaType(path: string) {
-        const liveType = ['m3u8']
-        const videoType = [
-            'avi',
-            'flv',
-            'm2v',
-            'm4v',
-            'mkv',
-            'mov',
-            'mp4',
-            'mpeg',
-            'mpg',
-            'mts',
-            'mxf',
-            'ts',
-            'vob',
-            'ogv',
-            'webm',
-            'wmv',
-        ]
-        const audioType = ['aac', 'aiff', 'flac', 'm4a', 'mp2', 'mp3', 'ogg', 'opus', 'wav', 'wma']
         const imageType = [
             'apng',
             'avif',
@@ -141,21 +157,31 @@ export const stringFormatter = () => {
             'tiff',
             'webp',
         ]
-        const ext = path.split('.').pop()
+        const ext = path.split('.').pop()?.toLowerCase()
 
         if (ext) {
-            if (liveType.includes(ext.toLowerCase())) {
+            if (liveMimeType[ext]) {
                 return 'live'
-            } else if (videoType.includes(ext.toLowerCase())) {
+            } else if (videoMimeTypeMap[ext]) {
                 return 'video'
-            } else if (audioType.includes(ext.toLowerCase())) {
+            } else if (audioMimeTypeMap[ext]) {
                 return 'audio'
-            } else if (imageType.includes(ext.toLowerCase())) {
+            } else if (imageType.includes(ext)) {
                 return 'image'
             }
         }
 
         return null
+    }
+
+    function mediaMimeType(path: string) {
+        const ext = path.split('.').pop()?.toLowerCase()
+
+        if (!ext) {
+            return null
+        }
+
+        return liveMimeType[ext] ?? videoMimeTypeMap[ext] ?? audioMimeTypeMap[ext] ?? null
     }
 
     function dir_file(path: string): { dir: string; file: string } {
@@ -177,6 +203,7 @@ export const stringFormatter = () => {
         toMin,
         secondsToTime,
         mediaType,
+        mediaMimeType,
         dir_file,
     }
 }

--- a/frontend/src/views/MediaView.vue
+++ b/frontend/src/views/MediaView.vue
@@ -343,7 +343,7 @@ const authStore = useAuth()
 const configStore = useConfig()
 const indexStore = useIndex()
 const mediaStore = useMedia()
-const { toMin, mediaType, filename, parent, dir_file } = stringFormatter()
+const { toMin, mediaType, mediaMimeType, filename, parent, dir_file } = stringFormatter()
 const { i } = storeToRefs(useConfig())
 
 const horizontal = ref(false)
@@ -492,12 +492,14 @@ function setPreviewData(path: string) {
     )
 
     const ext = previewName.value.split('.').slice(-1)[0].toLowerCase()
-    const fileType =
-        mediaType(previewName.value) === 'audio'
+    const currentType = mediaType(previewName.value)
+    const fallbackType =
+        currentType === 'audio'
             ? `audio/${ext}`
-            : mediaType(previewName.value) === 'live'
+            : currentType === 'live'
             ? 'application/x-mpegURL'
             : `video/${ext}`
+    const mimeType = mediaMimeType(previewName.value) ?? fallbackType
 
     if (configStore.playout.storage.extensions.includes(`${ext}`)) {
         isVideo.value = true
@@ -509,7 +511,7 @@ function setPreviewData(path: string) {
             preload: 'auto',
             sources: [
                 {
-                    type: fileType,
+                    type: mimeType,
                     src: previewUrl.value,
                 },
             ],

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -276,7 +276,7 @@ import { usePlaylist } from '@/stores/playlist'
 
 const { locale, t } = useI18n()
 const { width } = useWindowSize({ initialWidth: 800 })
-const { mediaType } = stringFormatter()
+const { mediaType, mediaMimeType } = stringFormatter()
 const { processPlaylist, genUID } = playlistOperations()
 
 const authStore = useAuth()
@@ -388,13 +388,14 @@ function setPreviewData(path: string) {
     }
 
     const ext = previewName.value.split('.').slice(-1)[0].toLowerCase()
-
-    const fileType =
-        mediaType(previewName.value) === 'audio'
+    const currentType = mediaType(previewName.value)
+    const fallbackType =
+        currentType === 'audio'
             ? `audio/${ext}`
-            : mediaType(previewName.value) === 'live'
+            : currentType === 'live'
             ? 'application/x-mpegURL'
             : `video/${ext}`
+    const mimeType = mediaMimeType(previewName.value) ?? fallbackType
 
     if (configStore.playout.storage.extensions.includes(`${ext}`)) {
         isVideo.value = true
@@ -406,7 +407,7 @@ function setPreviewData(path: string) {
             preload: 'auto',
             sources: [
                 {
-                    type: fileType,
+                    type: mimeType,
                     src: previewUrl.value,
                 },
             ],


### PR DESCRIPTION
## Summary
- add shared MIME type mappings for common audio and video formats, including mkv
- use the shared helper to provide accurate MIME types when building media previews

## Testing
- npm run type-check
- npm run lint *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68c94645be7083248fba8ed3d444f4a8